### PR TITLE
Variable declaration

### DIFF
--- a/src/virtual_machine/ast.rs
+++ b/src/virtual_machine/ast.rs
@@ -57,7 +57,7 @@ pub enum Statement {
 #[derive(Debug, Clone, PartialEq)]
 pub struct VariableDeclarationNode {
     pub name: String,               // 変数名
-    pub var_type: String,           // 型 (例: "int")
+    pub var_type: Type,             // 型 (例: "int")
     pub value: Box<ExpressionNode>, // 初期化式 (リテラルや式)
 }
 
@@ -287,10 +287,11 @@ pub enum BinaryOperator {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Type {
-    Int,    // 整数型
-    Float,  // 浮動小数点型
-    String, // 文字列型
-    Void,   // Void 型 (戻り値がない)
+    Integer,  // 整数型
+    Float,    // 浮動小数点型
+    String,   // 文字列型
+    Void,     // Void 型 (戻り値がない)
+    Function, // 関数型
 }
 
 // リテラルの値の種類

--- a/src/virtual_machine/parser.rs
+++ b/src/virtual_machine/parser.rs
@@ -1,4 +1,5 @@
 mod core;
+mod declaration_parser;
 mod expression_parser;
 mod parser_error;
 mod statement_parser;

--- a/src/virtual_machine/parser.rs
+++ b/src/virtual_machine/parser.rs
@@ -37,6 +37,10 @@ impl Parser {
         &self.tokens[self.current]
     }
 
+    fn peek_next(&self) -> &Token {
+        &self.tokens[self.current + 1]
+    }
+
     fn advance(&mut self) -> &Token {
         self.current += 1;
         &self.tokens[self.current - 1]

--- a/src/virtual_machine/parser/core.rs
+++ b/src/virtual_machine/parser/core.rs
@@ -1,3 +1,4 @@
+use crate::virtual_machine::ast::Type;
 use crate::virtual_machine::parser::Parser;
 use crate::virtual_machine::parser::ParserError;
 use crate::virtual_machine::token::token_type::TokenType;
@@ -12,5 +13,20 @@ pub fn expect(parser: &mut Parser, token_type: TokenType) -> Result<(), ParserEr
             line: parser.peek().line,
             char_pos: parser.peek().char_pos,
         })
+    }
+}
+
+pub fn type_token_to_type(token_type: TokenType) -> Result<Type, ParserError> {
+    match token_type {
+        TokenType::IntType => Ok(Type::Integer),
+        TokenType::FloatType => Ok(Type::Float),
+        TokenType::StringType => Ok(Type::String),
+        TokenType::VoidType => Ok(Type::Void),
+        TokenType::Fn => Ok(Type::Function),
+        _ => Err(ParserError::TypeNotFound {
+            found: token_type,
+            line: 0,
+            char_pos: 0,
+        }),
     }
 }

--- a/src/virtual_machine/parser/declaration_parser.rs
+++ b/src/virtual_machine/parser/declaration_parser.rs
@@ -1,0 +1,73 @@
+use crate::virtual_machine::ast::VariableDeclarationNode;
+use crate::virtual_machine::ast::{ExpressionNode, Statement, Type};
+use crate::virtual_machine::parser::core::type_token_to_type;
+use crate::virtual_machine::parser::expression_parser::parse_expression;
+use crate::virtual_machine::parser::Parser;
+use crate::virtual_machine::parser::ParserError;
+use crate::virtual_machine::token::token_type::TokenType;
+
+pub(crate) fn parse_declaration(parser: &mut Parser) -> Result<Statement, ParserError> {
+    // letキーワードを読み飛ばす
+    parser.advance();
+
+    // 変数宣言と関数宣言をRoute
+    match parser.peek_next().token_type {
+        TokenType::Colon => parse_declaration_of_variable(parser),
+        TokenType::LeftParen => parse_declaration_of_function(parser),
+        _ => Err(ParserError::MismatchedToken {
+            expected: TokenType::Equal,
+            found: parser.peek().token_type.clone(),
+            line: parser.peek().line,
+            char_pos: parser.peek().char_pos,
+        }),
+    }
+}
+
+fn parse_declaration_of_variable(parser: &mut Parser) -> Result<Statement, ParserError> {
+    // 名前を読み取る
+    let name: String = match parser.peek().token_type.clone() {
+        TokenType::Identifier(name) => name,
+        _ => {
+            return Err(ParserError::MismatchedToken {
+                expected: TokenType::Identifier("variable name".to_string()),
+                found: parser.peek().token_type.clone(),
+                line: parser.peek().line,
+                char_pos: parser.peek().char_pos,
+            })
+        }
+    };
+    parser.advance();
+
+    // colonを読み飛ばす
+    parser.expect(TokenType::Colon)?;
+
+    // 型を読み取る
+    let type_token: TokenType = parser.peek().token_type.clone();
+    let variable_type: Type = type_token_to_type(type_token)?;
+    parser.advance();
+
+    // イコールを読み飛ばす
+    parser.expect(TokenType::Equal)?;
+
+    // 式をパース
+    let expr: ExpressionNode = parse_expression(parser)?;
+
+    // セミコロンを読み飛ばす
+    parser.expect(TokenType::Semicolon)?;
+
+    Ok(Statement::DeclarationOfVariable(Box::new(
+        VariableDeclarationNode {
+            name,
+            var_type: variable_type,
+            value: Box::new(expr),
+        },
+    )))
+}
+
+fn parse_declaration_of_function(parser: &mut Parser) -> Result<Statement, ParserError> {
+    Err(ParserError::NotImplementedError {
+        feature: "Function declaration".to_string(),
+        line: parser.peek().line,
+        char_pos: parser.peek().char_pos,
+    })
+}

--- a/src/virtual_machine/parser/declaration_parser.rs
+++ b/src/virtual_machine/parser/declaration_parser.rs
@@ -1,10 +1,12 @@
-use crate::virtual_machine::ast::VariableDeclarationNode;
-use crate::virtual_machine::ast::{ExpressionNode, Statement, Type};
-use crate::virtual_machine::parser::core::type_token_to_type;
-use crate::virtual_machine::parser::expression_parser::parse_expression;
+mod parse_declaration_of_function;
+mod parse_declaration_of_variable;
+
+use crate::virtual_machine::ast::{Statement, Type};
 use crate::virtual_machine::parser::Parser;
 use crate::virtual_machine::parser::ParserError;
 use crate::virtual_machine::token::token_type::TokenType;
+use parse_declaration_of_function::parse_declaration_of_function;
+use parse_declaration_of_variable::parse_declaration_of_variable;
 
 pub(crate) fn parse_declaration(parser: &mut Parser) -> Result<Statement, ParserError> {
     // letキーワードを読み飛ばす
@@ -21,53 +23,4 @@ pub(crate) fn parse_declaration(parser: &mut Parser) -> Result<Statement, Parser
             char_pos: parser.peek().char_pos,
         }),
     }
-}
-
-fn parse_declaration_of_variable(parser: &mut Parser) -> Result<Statement, ParserError> {
-    // 名前を読み取る
-    let name: String = match parser.peek().token_type.clone() {
-        TokenType::Identifier(name) => name,
-        _ => {
-            return Err(ParserError::MismatchedToken {
-                expected: TokenType::Identifier("variable name".to_string()),
-                found: parser.peek().token_type.clone(),
-                line: parser.peek().line,
-                char_pos: parser.peek().char_pos,
-            })
-        }
-    };
-    parser.advance();
-
-    // colonを読み飛ばす
-    parser.expect(TokenType::Colon)?;
-
-    // 型を読み取る
-    let type_token: TokenType = parser.peek().token_type.clone();
-    let variable_type: Type = type_token_to_type(type_token)?;
-    parser.advance();
-
-    // イコールを読み飛ばす
-    parser.expect(TokenType::Equal)?;
-
-    // 式をパース
-    let expr: ExpressionNode = parse_expression(parser)?;
-
-    // セミコロンを読み飛ばす
-    parser.expect(TokenType::Semicolon)?;
-
-    Ok(Statement::DeclarationOfVariable(Box::new(
-        VariableDeclarationNode {
-            name,
-            var_type: variable_type,
-            value: Box::new(expr),
-        },
-    )))
-}
-
-fn parse_declaration_of_function(parser: &mut Parser) -> Result<Statement, ParserError> {
-    Err(ParserError::NotImplementedError {
-        feature: "Function declaration".to_string(),
-        line: parser.peek().line,
-        char_pos: parser.peek().char_pos,
-    })
 }

--- a/src/virtual_machine/parser/declaration_parser/parse_declaration_of_function.rs
+++ b/src/virtual_machine/parser/declaration_parser/parse_declaration_of_function.rs
@@ -1,0 +1,11 @@
+use crate::virtual_machine::ast::Statement;
+use crate::virtual_machine::parser::parser_error::ParserError;
+use crate::virtual_machine::parser::Parser;
+
+pub(crate) fn parse_declaration_of_function(parser: &mut Parser) -> Result<Statement, ParserError> {
+    Err(ParserError::NotImplementedError {
+        feature: "Function declaration".to_string(),
+        line: parser.peek().line,
+        char_pos: parser.peek().char_pos,
+    })
+}

--- a/src/virtual_machine/parser/declaration_parser/parse_declaration_of_variable.rs
+++ b/src/virtual_machine/parser/declaration_parser/parse_declaration_of_variable.rs
@@ -1,0 +1,48 @@
+use crate::virtual_machine::ast::VariableDeclarationNode;
+use crate::virtual_machine::ast::{ExpressionNode, Statement, Type};
+use crate::virtual_machine::parser::core::type_token_to_type;
+use crate::virtual_machine::parser::expression_parser::parse_expression;
+use crate::virtual_machine::parser::Parser;
+use crate::virtual_machine::parser::ParserError;
+use crate::virtual_machine::token::token_type::TokenType;
+
+pub(crate) fn parse_declaration_of_variable(parser: &mut Parser) -> Result<Statement, ParserError> {
+    // 名前を読み取る
+    let name: String = match parser.peek().token_type.clone() {
+        TokenType::Identifier(name) => name,
+        _ => {
+            return Err(ParserError::MismatchedToken {
+                expected: TokenType::Identifier("variable name".to_string()),
+                found: parser.peek().token_type.clone(),
+                line: parser.peek().line,
+                char_pos: parser.peek().char_pos,
+            })
+        }
+    };
+    parser.advance();
+
+    // colonを読み飛ばす
+    parser.expect(TokenType::Colon)?;
+
+    // 型を読み取る
+    let type_token: TokenType = parser.peek().token_type.clone();
+    let variable_type: Type = type_token_to_type(type_token)?;
+    parser.advance();
+
+    // イコールを読み飛ばす
+    parser.expect(TokenType::Equal)?;
+
+    // 式をパース
+    let expr: ExpressionNode = parse_expression(parser)?;
+
+    // セミコロンを読み飛ばす
+    parser.expect(TokenType::Semicolon)?;
+
+    Ok(Statement::DeclarationOfVariable(Box::new(
+        VariableDeclarationNode {
+            name,
+            var_type: variable_type,
+            value: Box::new(expr),
+        },
+    )))
+}

--- a/src/virtual_machine/parser/parser_error.rs
+++ b/src/virtual_machine/parser/parser_error.rs
@@ -16,6 +16,12 @@ pub enum ParserError {
         line: usize,
         char_pos: usize,
     },
+    #[error("could not found {found:?} type in Shot at line {line}, position {char_pos}")]
+    TypeNotFound {
+        found: TokenType,
+        line: usize,
+        char_pos: usize,
+    },
     #[error("Unexpected end of input while parsing, expected {expected:?}")]
     UnexpectedEof { expected: TokenType },
     #[error("Not implemented: {feature} at line {line}, position {char_pos}")]

--- a/src/virtual_machine/parser/statement_parser.rs
+++ b/src/virtual_machine/parser/statement_parser.rs
@@ -1,28 +1,16 @@
-use crate::virtual_machine::ast::{ExpressionNode, Statement};
+use crate::virtual_machine::ast::{ExpressionNode, Statement, Type, VariableDeclarationNode};
+use crate::virtual_machine::parser::core::type_token_to_type;
 use crate::virtual_machine::parser::expression_parser::parse_expression;
 use crate::virtual_machine::parser::Parser;
 use crate::virtual_machine::parser::ParserError;
 use crate::virtual_machine::token::token_type::TokenType;
+use crate::virtual_machine::token::Token;
 
 pub fn parse_statement(parser: &mut Parser) -> Result<Statement, ParserError> {
     match parser.peek().token_type.clone() {
         TokenType::Let => {
-            // 仮実装: 変数宣言のパース
-            let token = parser.peek().clone();
-            Err(ParserError::NotImplementedError {
-                feature: "Variable declaration".to_string(),
-                line: token.line,
-                char_pos: token.char_pos,
-            })
-        }
-        TokenType::Fn => {
-            // 仮実装: 関数宣言のパース
-            let token = parser.peek().clone();
-            Err(ParserError::NotImplementedError {
-                feature: "Function declaration".to_string(),
-                line: token.line,
-                char_pos: token.char_pos,
-            })
+            // let文のパース
+            parse_let_statement(parser)
         }
         TokenType::Return => {
             // return文のパース
@@ -33,6 +21,72 @@ pub fn parse_statement(parser: &mut Parser) -> Result<Statement, ParserError> {
             parse_expression_statement(parser)
         }
     }
+}
+
+fn parse_let_statement(parser: &mut Parser) -> Result<Statement, ParserError> {
+    // letキーワードを読み飛ばす
+    parser.advance();
+
+    // 変数宣言と関数宣言をRoute
+    match parser.peek_next().token_type {
+        TokenType::Colon => parse_declaration_of_variable(parser),
+        TokenType::LeftParen => parse_declaration_of_function(parser),
+        _ => Err(ParserError::MismatchedToken {
+            expected: TokenType::Equal,
+            found: parser.peek().token_type.clone(),
+            line: parser.peek().line,
+            char_pos: parser.peek().char_pos,
+        }),
+    }
+}
+
+fn parse_declaration_of_variable(parser: &mut Parser) -> Result<Statement, ParserError> {
+    // 名前を読み取る
+    let name: String = match parser.peek().token_type.clone() {
+        TokenType::Identifier(name) => name,
+        _ => {
+            return Err(ParserError::MismatchedToken {
+                expected: TokenType::Identifier("variable name".to_string()),
+                found: parser.peek().token_type.clone(),
+                line: parser.peek().line,
+                char_pos: parser.peek().char_pos,
+            })
+        }
+    };
+    parser.advance();
+
+    // colonを読み飛ばす
+    parser.expect(TokenType::Colon)?;
+
+    // 型を読み取る
+    let type_token: TokenType = parser.peek().token_type.clone();
+    let variable_type: Type = type_token_to_type(type_token)?;
+    parser.advance();
+
+    // イコールを読み飛ばす
+    parser.expect(TokenType::Equal)?;
+
+    // 式をパース
+    let expr: ExpressionNode = parse_expression(parser)?;
+
+    // セミコロンを読み飛ばす
+    parser.expect(TokenType::Semicolon)?;
+
+    Ok(Statement::DeclarationOfVariable(Box::new(
+        VariableDeclarationNode {
+            name,
+            var_type: variable_type,
+            value: Box::new(expr),
+        },
+    )))
+}
+
+fn parse_declaration_of_function(parser: &mut Parser) -> Result<Statement, ParserError> {
+    Err(ParserError::NotImplementedError {
+        feature: "Function declaration".to_string(),
+        line: parser.peek().line,
+        char_pos: parser.peek().char_pos,
+    })
 }
 
 fn parse_return_statement(parser: &mut Parser) -> Result<Statement, ParserError> {

--- a/src/virtual_machine/parser/statement_parser.rs
+++ b/src/virtual_machine/parser/statement_parser.rs
@@ -1,11 +1,11 @@
 use crate::virtual_machine::ast::{ExpressionNode, Statement, Type, VariableDeclarationNode};
 use crate::virtual_machine::parser::core::type_token_to_type;
+use crate::virtual_machine::parser::declaration_parser::parse_declaration;
 use crate::virtual_machine::parser::expression_parser::parse_expression;
 use crate::virtual_machine::parser::Parser;
 use crate::virtual_machine::parser::ParserError;
 use crate::virtual_machine::token::token_type::TokenType;
 use crate::virtual_machine::token::Token;
-
 pub fn parse_statement(parser: &mut Parser) -> Result<Statement, ParserError> {
     match parser.peek().token_type.clone() {
         TokenType::Let => {
@@ -24,69 +24,7 @@ pub fn parse_statement(parser: &mut Parser) -> Result<Statement, ParserError> {
 }
 
 fn parse_let_statement(parser: &mut Parser) -> Result<Statement, ParserError> {
-    // letキーワードを読み飛ばす
-    parser.advance();
-
-    // 変数宣言と関数宣言をRoute
-    match parser.peek_next().token_type {
-        TokenType::Colon => parse_declaration_of_variable(parser),
-        TokenType::LeftParen => parse_declaration_of_function(parser),
-        _ => Err(ParserError::MismatchedToken {
-            expected: TokenType::Equal,
-            found: parser.peek().token_type.clone(),
-            line: parser.peek().line,
-            char_pos: parser.peek().char_pos,
-        }),
-    }
-}
-
-fn parse_declaration_of_variable(parser: &mut Parser) -> Result<Statement, ParserError> {
-    // 名前を読み取る
-    let name: String = match parser.peek().token_type.clone() {
-        TokenType::Identifier(name) => name,
-        _ => {
-            return Err(ParserError::MismatchedToken {
-                expected: TokenType::Identifier("variable name".to_string()),
-                found: parser.peek().token_type.clone(),
-                line: parser.peek().line,
-                char_pos: parser.peek().char_pos,
-            })
-        }
-    };
-    parser.advance();
-
-    // colonを読み飛ばす
-    parser.expect(TokenType::Colon)?;
-
-    // 型を読み取る
-    let type_token: TokenType = parser.peek().token_type.clone();
-    let variable_type: Type = type_token_to_type(type_token)?;
-    parser.advance();
-
-    // イコールを読み飛ばす
-    parser.expect(TokenType::Equal)?;
-
-    // 式をパース
-    let expr: ExpressionNode = parse_expression(parser)?;
-
-    // セミコロンを読み飛ばす
-    parser.expect(TokenType::Semicolon)?;
-
-    Ok(Statement::DeclarationOfVariable(Box::new(
-        VariableDeclarationNode {
-            name,
-            var_type: variable_type,
-            value: Box::new(expr),
-        },
-    )))
-}
-
-fn parse_declaration_of_function(parser: &mut Parser) -> Result<Statement, ParserError> {
-    Err(ParserError::NotImplementedError {
-        feature: "Function declaration".to_string(),
-        line: parser.peek().line,
-        char_pos: parser.peek().char_pos,
-    })
+    parse_declaration(parser)
 }
 
 fn parse_return_statement(parser: &mut Parser) -> Result<Statement, ParserError> {


### PR DESCRIPTION
Now Shot parser can recognize variable declaration!!

```shell
./target/debug/shot -i "let a: int = 1;" -d
Scanned Tokens:
  Let
  Identifier("a")
  Colon
  IntType
  Equal
  IntegerLiteral(1)
  Semicolon
  Eof


AST is created:
  AST[0]:
    AST { line: 1, statement: DeclarationOfVariable(VariableDeclarationNode { name: "a", var_type: Integer, value: Literal(LiteralNode { value: Integer(1) }) }) }
```