### PR TITLE
Add test and fix parsing expression in parenthesis

### DIFF
--- a/src/virtual_machine/parser/expression_parser/parse_parenthesized.rs
+++ b/src/virtual_machine/parser/expression_parser/parse_parenthesized.rs
@@ -1,23 +1,22 @@
-use crate::virtual_machine::ast::ExpressionNode;
+use crate::virtual_machine::ast::{ExpressionNode, LiteralNode, LiteralValue};
 use crate::virtual_machine::parser::expression_parser::parse_binary::parse_binary;
 use crate::virtual_machine::parser::parser_error::ParserError;
 use crate::virtual_machine::parser::Parser;
 use crate::virtual_machine::token::token_type::TokenType;
 
 pub fn parse_parenthesized(parser: &mut Parser) -> Result<ExpressionNode, ParserError> {
-    parser.check_advance(TokenType::LeftParen)?; // 左括弧を消費
+    // 左括弧がなければエラー、あれば次のトークンに進む
+    parser.check_advance(TokenType::LeftParen)?;
 
     // 中身が空かをチェック
     if parser.check(TokenType::RightParen) {
-        return Err(ParserError::UnexpectedTokenType {
-            token: parser.peek().token_type.clone(),
-            line: parser.peek().line,
-            char_pos: parser.peek().char_pos,
-        });
+        return Ok(ExpressionNode::Literal(Box::new(LiteralNode {
+            value: LiteralValue::None,
+        })));
     }
 
     // 括弧内の式をパース (優先順位に基づくパース)
-    let expr = parse_binary(parser)?;
+    let expr: ExpressionNode = parse_binary(parser)?;
 
     // 右括弧があるかを確認し、なければエラー
     parser
@@ -35,7 +34,6 @@ pub fn parse_parenthesized(parser: &mut Parser) -> Result<ExpressionNode, Parser
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::virtual_machine::ast::{ExpressionNode, LiteralValue};
     use crate::virtual_machine::parser::Parser;
     use crate::virtual_machine::token::{token_type::TokenType, Token};
 
@@ -45,115 +43,49 @@ mod tests {
         Parser::new(tokens_with_eof)
     }
 
-    #[test]
-    fn test_parse_valid_parenthesized_expression() {
-        let tokens = vec![
-            Token::new(1, 1, TokenType::LeftParen),
-            Token::new(1, 2, TokenType::IntegerLiteral(42)),
-            Token::new(1, 3, TokenType::RightParen),
-        ];
-        let mut parser = create_parser_with_tokens(tokens);
-
-        let result = parse_parenthesized(&mut parser);
-        assert!(result.is_ok());
-
-        match result.unwrap() {
-            ExpressionNode::Literal(literal) => {
-                assert_eq!(literal.value, LiteralValue::Integer(42));
-            }
-            _ => panic!("Expected integer literal inside parentheses"),
-        }
-    }
-
+    /// 空の括弧内の式をパースするテスト
+    /// test case: `()`
     #[test]
     fn test_parse_empty_parenthesized_expression() {
-        let tokens = vec![
+        let tokens: Vec<Token> = vec![
             Token::new(1, 1, TokenType::LeftParen),
             Token::new(1, 2, TokenType::RightParen), // 空の括弧
         ];
-        let mut parser = create_parser_with_tokens(tokens);
+        let mut parser: Parser = create_parser_with_tokens(tokens);
 
-        let result = parse_parenthesized(&mut parser);
-        assert!(result.is_err());
+        let result: Result<ExpressionNode, ParserError> = parse_parenthesized(&mut parser);
+        assert!(result.is_ok());
 
-        match result {
-            Err(ParserError::UnexpectedTokenType { token, .. }) => {
-                assert_eq!(token, TokenType::RightParen);
-            }
-            _ => panic!("Expected UnexpectedTokenType error for empty parentheses"),
-        }
+        let expr: ExpressionNode = result.unwrap();
+        assert_eq!(
+            expr,
+            ExpressionNode::Literal(Box::new(LiteralNode {
+                value: LiteralValue::None,
+            }))
+        );
     }
 
-    #[test]
-    fn test_parse_missing_right_paren() {
-        let tokens = vec![
-            Token::new(1, 1, TokenType::LeftParen),
-            Token::new(1, 2, TokenType::IntegerLiteral(42)),
-            // 右括弧がない
-        ];
-        let mut parser = create_parser_with_tokens(tokens);
-
-        let result = parse_parenthesized(&mut parser);
-        assert!(result.is_err());
-
-        match result {
-            Err(ParserError::MismatchedToken {
-                expected, found, ..
-            }) => {
-                assert_eq!(expected, TokenType::RightParen);
-                assert_eq!(found, TokenType::Eof);
-            }
-            _ => panic!("Expected MismatchedToken error for missing right parenthesis"),
-        }
-    }
-
+    /// 多重の括弧を含む式をパースするテスト
+    /// test case: `(())`
     #[test]
     fn test_parse_nested_parenthesized_expression() {
-        let tokens = vec![
+        let tokens: Vec<Token> = vec![
             Token::new(1, 1, TokenType::LeftParen),
             Token::new(1, 2, TokenType::LeftParen),
-            Token::new(1, 3, TokenType::IntegerLiteral(10)),
             Token::new(1, 4, TokenType::RightParen),
             Token::new(1, 5, TokenType::RightParen),
         ];
-        let mut parser = create_parser_with_tokens(tokens);
+        let mut parser: Parser = create_parser_with_tokens(tokens);
 
-        let result = parse_parenthesized(&mut parser);
+        let result: Result<ExpressionNode, ParserError> = parse_parenthesized(&mut parser);
         assert!(result.is_ok());
 
-        match result.unwrap() {
-            ExpressionNode::Literal(literal) => {
-                assert_eq!(literal.value, LiteralValue::Integer(10));
-            }
-            _ => panic!("Expected nested parentheses with integer literal inside"),
-        }
-    }
-
-    pub fn parse_parenthesized(parser: &mut Parser) -> Result<ExpressionNode, ParserError> {
-        parser.check_advance(TokenType::LeftParen)?; // 左括弧を消費
-
-        // 中身が空かをチェック
-        if parser.check(TokenType::RightParen) {
-            return Err(ParserError::UnexpectedTokenType {
-                token: parser.peek().token_type.clone(),
-                line: parser.peek().line,
-                char_pos: parser.peek().char_pos,
-            });
-        }
-
-        // 括弧内の式をパース (優先順位に基づくパース)
-        let expr = parse_binary(parser)?;
-
-        // 右括弧があるかを確認し、なければエラー
-        parser
-            .check_advance(TokenType::RightParen)
-            .map_err(|_| ParserError::MismatchedToken {
-                expected: TokenType::RightParen,
-                found: parser.peek().token_type.clone(),
-                line: parser.peek().line,
-                char_pos: parser.peek().char_pos,
-            })?;
-
-        Ok(expr)
+        let expr: ExpressionNode = result.unwrap();
+        assert_eq!(
+            expr,
+            ExpressionNode::Literal(Box::new(LiteralNode {
+                value: LiteralValue::None,
+            }))
+        );
     }
 }

--- a/src/virtual_machine/parser/expression_parser/parse_parenthesized.rs
+++ b/src/virtual_machine/parser/expression_parser/parse_parenthesized.rs
@@ -1,5 +1,5 @@
 use crate::virtual_machine::ast::{ExpressionNode, LiteralNode, LiteralValue};
-use crate::virtual_machine::parser::expression_parser::parse_binary::parse_binary;
+use crate::virtual_machine::parser::expression_parser::parse_expression;
 use crate::virtual_machine::parser::parser_error::ParserError;
 use crate::virtual_machine::parser::Parser;
 use crate::virtual_machine::token::token_type::TokenType;
@@ -25,7 +25,7 @@ pub fn parse_parenthesized(parser: &mut Parser) -> Result<ExpressionNode, Parser
     }
 
     // 括弧内の式をパース (優先順位に基づくパース)
-    let expr: ExpressionNode = parse_binary(parser)?;
+    let expr: ExpressionNode = parse_expression(parser)?;
 
     // 右括弧があるかを確認し、なければエラー
     parser

--- a/src/virtual_machine/parser/expression_parser/parse_parenthesized.rs
+++ b/src/virtual_machine/parser/expression_parser/parse_parenthesized.rs
@@ -4,6 +4,15 @@ use crate::virtual_machine::parser::parser_error::ParserError;
 use crate::virtual_machine::parser::Parser;
 use crate::virtual_machine::token::token_type::TokenType;
 
+/// # 括弧内の式をパース
+///
+/// ## Abstract
+///
+/// 括弧内の式をパースします。
+///
+/// ## Note
+///
+/// () や (()) のような括弧内の式の場合、LiteralNode::NoneなるExpressionNodeを返します。
 pub fn parse_parenthesized(parser: &mut Parser) -> Result<ExpressionNode, ParserError> {
     // 左括弧がなければエラー、あれば次のトークンに進む
     parser.check_advance(TokenType::LeftParen)?;

--- a/src/virtual_machine/parser/statement_parser.rs
+++ b/src/virtual_machine/parser/statement_parser.rs
@@ -4,6 +4,7 @@ use crate::virtual_machine::parser::expression_parser::parse_expression;
 use crate::virtual_machine::parser::Parser;
 use crate::virtual_machine::parser::ParserError;
 use crate::virtual_machine::token::token_type::TokenType;
+
 pub fn parse_statement(parser: &mut Parser) -> Result<Statement, ParserError> {
     match parser.peek().token_type.clone() {
         TokenType::Let => {
@@ -37,6 +38,31 @@ fn parse_return_statement(parser: &mut Parser) -> Result<Statement, ParserError>
     Ok(Statement::Return(Box::new(expr)))
 }
 
+/// # 式文（Expression Statement）のパース
+///
+/// 式文は、式の末尾にセミコロンがついたものです。
+///
+/// ## Syntax
+///
+/// ```text
+/// expression_statement = expression_node ";"
+/// ```
+///
+/// ## Note
+///
+/// 式文は下記のような定義になっています。
+///
+/// ```
+/// pub enum ExpressionNode {
+//     BinaryOperation(Box<BinaryOperationNode>), // 二項演算
+//     CallOfFunction(Box<FunctionCallNode>),     // 関数呼び出し
+//     CallOfVariable(Box<VariableCallNode>),     // 識別子
+//     Literal(Box<LiteralNode>),                 // リテラル
+//     TypeCast(Box<TypeCastNode>),               // 型キャスト
+/// }
+/// ```
+///
+/// このうち `BinaryOperation` などの式は、内部にさらに式を持つことがあります。
 fn parse_expression_statement(parser: &mut Parser) -> Result<Statement, ParserError> {
     // 式をパース
     let expr: ExpressionNode = parse_expression(parser)?;

--- a/tests/virtual_machine/parser/expression_parser/test_parse_parenthesized.rs
+++ b/tests/virtual_machine/parser/expression_parser/test_parse_parenthesized.rs
@@ -1,0 +1,86 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::virtual_machine::ast::{ExpressionNode, LiteralValue};
+    use crate::virtual_machine::parser::Parser;
+    use crate::virtual_machine::token::{token_type::TokenType, Token};
+
+    fn create_parser_with_tokens(tokens: Vec<Token>) -> Parser {
+        let mut tokens_with_eof = tokens.clone();
+        tokens_with_eof.push(Token::new(1, 1, TokenType::Eof)); // EOFを追加
+        Parser::new(tokens_with_eof)
+    }
+
+    /// 数値リテラルを含む括弧内の式をパースするテスト
+    /// test case: `(1)`
+    #[test]
+    fn test_parse_valid_parenthesized_expression() {
+        let tokens = vec![
+            Token::new(1, 1, TokenType::LeftParen),
+            Token::new(1, 2, TokenType::IntegerLiteral(42)),
+            Token::new(1, 3, TokenType::RightParen),
+        ];
+        let mut parser = create_parser_with_tokens(tokens);
+
+        let result = parse_parenthesized(&mut parser);
+        assert!(result.is_ok());
+
+        match result.unwrap() {
+            ExpressionNode::Literal(literal) => {
+                assert_eq!(literal.value, LiteralValue::Integer(42));
+            }
+            _ => panic!("Expected integer literal inside parentheses"),
+        }
+    }
+
+    /// 右の括弧がない空の括弧内の式をパースするテスト
+    /// test case: `(1`
+    /// 期待されるエラー: UnexpectedTokenType
+    /// 期待されるエラーメッセージ: "Unexpected token: RightParen"
+    #[test]
+    fn test_parse_missing_right_paren() {
+        let tokens = vec![
+            Token::new(1, 1, TokenType::LeftParen),
+            Token::new(1, 2, TokenType::IntegerLiteral(42)),
+            // 右括弧がない
+        ];
+        let mut parser = create_parser_with_tokens(tokens);
+
+        let result = parse_parenthesized(&mut parser);
+        assert!(result.is_err());
+
+        match result {
+            Err(ParserError::MismatchedToken {
+                    expected, found, ..
+                }) => {
+                assert_eq!(expected, TokenType::RightParen);
+                assert_eq!(found, TokenType::Eof);
+            }
+            _ => panic!("Expected MismatchedToken error for missing right parenthesis"),
+        }
+    }
+
+    /// 多重の括弧を含む式をパースするテスト
+    /// test case: `((10))`
+    #[test]
+    fn test_parse_nested_parenthesized_expression() {
+        let tokens = vec![
+            Token::new(1, 1, TokenType::LeftParen),
+            Token::new(1, 2, TokenType::LeftParen),
+            Token::new(1, 3, TokenType::IntegerLiteral(10)),
+            Token::new(1, 4, TokenType::RightParen),
+            Token::new(1, 5, TokenType::RightParen),
+        ];
+        let mut parser = create_parser_with_tokens(tokens);
+
+        let result = parse_parenthesized(&mut parser);
+        assert!(result.is_ok());
+
+        match result.unwrap() {
+            ExpressionNode::Literal(literal) => {
+                assert_eq!(literal.value, LiteralValue::Integer(10));
+            }
+            _ => panic!("Expected nested parentheses with integer literal inside"),
+        }
+    }
+}

--- a/tests/virtual_machine/parser/expression_parser/test_parse_parenthesized.rs
+++ b/tests/virtual_machine/parser/expression_parser/test_parse_parenthesized.rs
@@ -83,4 +83,45 @@ mod tests {
             _ => panic!("Expected nested parentheses with integer literal inside"),
         }
     }
+
+    /// 括弧内の式をパースするテスト
+    /// test case: `(1 + 1)`
+    #[test]
+    fn test_parse_valid_parenthesized_expression() {
+        let tokens = vec![
+            Token::new(1, 1, TokenType::LeftParen),
+            Token::new(1, 2, TokenType::IntegerLiteral(1)),
+            Token::new(1, 3, TokenType::BinaryOperator(TokenType::Plus)),
+            Token::new(1, 4, TokenType::IntegerLiteral(1)),
+            Token::new(1, 3, TokenType::RightParen),
+        ];
+        let mut parser = create_parser_with_tokens(tokens);
+
+        let result = parse_parenthesized(&mut parser);
+        assert!(result.is_ok());
+
+        let binary_op = match result.unwrap() {
+            ExpressionNode::BinaryOperation(binary_op) => binary_op,
+            _ => panic!("Expected binary operation inside parentheses"),
+        };
+
+        match *binary_op.left {
+            ExpressionNode::Literal(literal) => {
+                assert_eq!(literal.value, LiteralValue::Integer(1));
+            }
+            _ => panic!("Expected integer literal inside binary operation"),
+        }
+
+        match *binary_op.right {
+            ExpressionNode::Literal(literal) => {
+                assert_eq!(literal.value, LiteralValue::Integer(1));
+            }
+            _ => panic!("Expected integer literal inside binary operation"),
+        }
+
+        match binary_op.operator {
+            TokenType::Plus => {}
+            _ => panic!("Expected plus operator in binary operation"),
+        }
+    }
 }


### PR DESCRIPTION
Add test and fix parsing expression in parenthesis.

## fix bug when expression in parenthesis

```shell
shot (add_unit_test_for_parser) » ./target/debug/shot -i "(x);" -d                                               ~/Hobby/shot 
Scanned Tokens:
  LeftParen
  Identifier("x")
  RightParen
  Semicolon
  Eof


AST is created:
  AST[0]:
    AST { line: 1, statement: Expression(CallOfVariable(VariableCallNode { name: "x" })) }


shot (add_unit_test_for_parser) » ./target/debug/shot -i "(1 + 1);" -d                                                ~/Hobby/shot
Scanned Tokens:
  LeftParen
  IntegerLiteral(1)
  Plus
  IntegerLiteral(1)
  RightParen
  Semicolon
  Eof


AST is created:
  AST[0]:
    AST { line: 1, statement: Expression(BinaryOperation(BinaryOperationNode { left: Literal(LiteralNode { value: Integer(1) }), operator: Add, right: Literal(LiteralNode { value: Integer(1) }) })) }
```