### PR TITLE
refactor: get_type と type_to_token_type をget_type_from_curernt_tokenに統一

### DIFF
--- a/src/virtual_machine/parser/core.rs
+++ b/src/virtual_machine/parser/core.rs
@@ -7,25 +7,29 @@ use crate::virtual_machine::token::token_type::TokenType;
 #[allow(unused_imports)]
 use crate::virtual_machine::token::Token;
 
-/// 入力されたトークンをShot言語の型のトークンに対応する型に変換する
+/// パーサーの現在のトークンから型情報を取得する
 ///
 /// # Arguments
-/// - `token_type`: 変換するトークン
+/// - `parser`: Parser
 ///
 /// # Returns
 /// - `Type`: 変換された型
 /// - `ParserError::TypeNotFound`: 型が見つからなかった場合
-pub fn type_token_to_type(token_type: TokenType) -> Result<Type, ParserError> {
-    match token_type {
+///
+/// # Raises
+/// - `ParserError::TypeNotFound`: 型が見つからなかった場合
+pub fn get_type_from_current_token(parser: &mut Parser) -> Result<Type, ParserError> {
+    let current_token: Token = parser.peek().clone();
+    match current_token.token_type.clone() {
         TokenType::IntType => Ok(Type::Integer),
         TokenType::FloatType => Ok(Type::Float),
         TokenType::StringType => Ok(Type::String),
         TokenType::VoidType => Ok(Type::Void),
         TokenType::Fn => Ok(Type::Function),
         _ => Err(ParserError::TypeNotFound {
-            found: token_type,
-            line: 0,
-            char_pos: 0,
+            found: current_token.token_type.clone(),
+            line: current_token.line,
+            char_pos: current_token.char_pos,
         }),
     }
 }

--- a/src/virtual_machine/parser/declaration_parser/parse_declaration_of_function.rs
+++ b/src/virtual_machine/parser/declaration_parser/parse_declaration_of_function.rs
@@ -1,5 +1,6 @@
 use crate::virtual_machine::ast::FunctionDeclarationNode;
 use crate::virtual_machine::ast::{Statement, Type};
+use crate::virtual_machine::parser::core::get_type_from_current_token;
 use crate::virtual_machine::parser::parser_error::ParserError;
 use crate::virtual_machine::parser::parser_error::ParserError::{MismatchedToken, UnexpectedEof};
 use crate::virtual_machine::parser::statement_parser::parse_statement;
@@ -76,7 +77,7 @@ pub(crate) fn parse_declaration_of_function(parser: &mut Parser) -> Result<State
 
     // 戻り値の型を確認する
     // let f: fn = (x: int, y: float): string
-    let return_type: Type = get_type(parser)?;
+    let return_type: Type = get_type_from_current_token(parser)?;
     parser.advance();
 
     // 左波括弧があることを確認して読み飛ばす
@@ -127,7 +128,7 @@ fn parse_parameters(parser: &mut Parser) -> Result<Vec<(String, Type)>, ParserEr
         parser.check_advance(TokenType::Colon)?;
 
         // 型情報を取得
-        let parameter_type: Type = get_type(parser)?;
+        let parameter_type: Type = get_type_from_current_token(parser)?;
         parser.advance();
 
         // 引数と型の組みをpush
@@ -179,23 +180,6 @@ fn parse_function_body(parser: &mut Parser) -> Result<Vec<Statement>, ParserErro
         }
     }
     Ok(statements)
-}
-
-fn get_type(parser: &mut Parser) -> Result<Type, ParserError> {
-    let token: TokenType = parser.peek().token_type.clone();
-    match token {
-        TokenType::IntType => Ok(Type::Integer),
-        TokenType::FloatType => Ok(Type::Float),
-        TokenType::StringType => Ok(Type::String),
-        TokenType::VoidType => Ok(Type::Void),
-        TokenType::Fn => Ok(Type::Function),
-        token => Err(MismatchedToken {
-            expected: TokenType::Identifier(String::from("parameter_name")),
-            found: token.clone(),
-            line: parser.peek().line,
-            char_pos: parser.peek().char_pos,
-        }),
-    }
 }
 
 #[cfg(test)]

--- a/src/virtual_machine/parser/declaration_parser/parse_declaration_of_variable.rs
+++ b/src/virtual_machine/parser/declaration_parser/parse_declaration_of_variable.rs
@@ -1,6 +1,6 @@
 use crate::virtual_machine::ast::VariableDeclarationNode;
 use crate::virtual_machine::ast::{ExpressionNode, Statement, Type};
-use crate::virtual_machine::parser::core::type_token_to_type;
+use crate::virtual_machine::parser::core::get_type_from_current_token;
 use crate::virtual_machine::parser::expression_parser::parse_expression;
 use crate::virtual_machine::parser::Parser;
 use crate::virtual_machine::parser::ParserError;
@@ -44,8 +44,7 @@ pub fn parse_declaration_of_variable(parser: &mut Parser) -> Result<Statement, P
     parser.check_advance(TokenType::Colon)?;
 
     // 型を読み取る
-    let type_token: TokenType = parser.peek().token_type.clone();
-    let variable_type: Type = type_token_to_type(type_token)?;
+    let variable_type: Type = get_type_from_current_token(parser)?;
     parser.advance();
 
     // イコールを読み飛ばす

--- a/src/virtual_machine/parser/expression_parser/parse_type_cast.rs
+++ b/src/virtual_machine/parser/expression_parser/parse_type_cast.rs
@@ -1,5 +1,5 @@
 use crate::virtual_machine::ast::{ExpressionNode, Type, TypeCastNode};
-use crate::virtual_machine::parser::core::type_token_to_type;
+use crate::virtual_machine::parser::core::get_type_from_current_token;
 use crate::virtual_machine::parser::parser_error::ParserError;
 use crate::virtual_machine::parser::Parser;
 use crate::virtual_machine::token::token_type::TokenType;
@@ -21,14 +21,14 @@ pub fn parse_type_cast(
     parser.check_advance(TokenType::As)?;
 
     // 型を読み取る
-    let from_type: Type = type_token_to_type(parser.peek().token_type.clone())?;
+    let from_type: Type = get_type_from_current_token(parser)?;
     parser.advance();
 
     // -> を確認して読み飛ばす
     parser.check_advance(TokenType::TypeCastArrow)?;
 
     // 型を読み取る
-    let to_type: Type = type_token_to_type(parser.peek().token_type.clone())?;
+    let to_type: Type = get_type_from_current_token(parser)?;
     parser.advance();
 
     // 式を返す


### PR DESCRIPTION
get_typeのような型情報を確認して戻す関数が複数あったので統一